### PR TITLE
fix: Mopidy plugin must expose version number

### DIFF
--- a/mopidy_pummeluff/__init__.py
+++ b/mopidy_pummeluff/__init__.py
@@ -3,13 +3,15 @@ Mopidy Pummeluff Python module.
 '''
 
 import os
-
+import pkg_resources
 import mopidy
 
 from .frontend import PummeluffFrontend
 from .web import LatestHandler, RegistryHandler, RegisterHandler, UnregisterHandler, \
     ActionClassesHandler
 
+
+__version__ = pkg_resources.get_distribution('mopidy-pummeluff').version
 
 def app_factory(config, core):  # pylint: disable=unused-argument
     '''
@@ -37,6 +39,7 @@ class Extension(mopidy.ext.Extension):
 
     dist_name = 'Mopidy-Pummeluff'
     ext_name = 'pummeluff'
+    version = __version__
 
     def get_default_config(self):  # pylint: disable=no-self-use
         '''

--- a/mopidy_pummeluff/__init__.py
+++ b/mopidy_pummeluff/__init__.py
@@ -11,7 +11,7 @@ from .web import LatestHandler, RegistryHandler, RegisterHandler, UnregisterHand
     ActionClassesHandler
 
 
-__version__ = pkg_resources.get_distribution('mopidy-pummeluff').version
+__version__ = pkg_resources.get_distribution('Mopidy-Pummeluff').version
 
 def app_factory(config, core):  # pylint: disable=unused-argument
     '''


### PR DESCRIPTION
According to [Mopidy extension development page](https://docs.mopidy.com/en/latest/extensiondev/#example-init-py), an extension must expose a [PEP 396](https://www.python.org/dev/peps/pep-0386/) compliant version number.

Version number can be obtained from `pkg_resources`.